### PR TITLE
Updated extractor to fix doubling up on same URL

### DIFF
--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -110,7 +110,7 @@ func handleMessage(apiClient api.Client) messaging.MsgHandler {
 
 func extractResource(msg messaging.NewResourceMsg) (api.ResourceDto, []string, error) {
 	resDto := api.ResourceDto{
-		URL:   protocolRegex.ReplaceAllLiteralString(msg.URL, ""),
+		URL:   msg.URL,
 		Title: extractTitle(msg.Body),
 		Body:  msg.Body,
 		Time:  time.Now(),


### PR DESCRIPTION
It seems that the extractor saves the URL without the protocol, but the scheduler searches for the URL with the protocol attached.

extractor.go:
```
resDto := api.ResourceDto{
		URL:   protocolRegex.ReplaceAllLiteralString(msg.URL, ""), // here it sanitizes it..
		Title: extractTitle(msg.Body),
		Body:  msg.Body,
		Time:  time.Now(),
	}
```

scheduler.go:
`_, count, err := apiClient.SearchResources(u.String(), "", time.Time{}, endDate, 1, 1)`